### PR TITLE
Fix portal player y pos being off by 1 node sometimes

### DIFF
--- a/nether/portal.lua
+++ b/nether/portal.lua
@@ -649,13 +649,19 @@ local function set_portal(t, z,x, y)
 	t[z][x] = y
 end
 
+local function get_player_nodepos(player)
+	local pos = player:get_pos()
+	pos.y = pos.y + player:get_properties().collisionbox[2] + 0.5
+	return vector.round(pos)
+end
+
 -- used when a player eats that fruit in a portal
 function nether.teleport_player(player)
 	if not player then
 		minetest.log("error", "[nether] Missing player.")
 		return
 	end
-	local pos = vector.round(player:get_pos())
+	local pos = get_player_nodepos(player)
 	if not is_netherportal(pos) then
 		return
 	end


### PR DESCRIPTION
There were some changes in how vector.round rounds: https://github.com/minetest/minetest/pull/10803
=> It now rounds y down if at y<0 (i.e. in nether).

The new pos uses the highest node that contains the feet.

(collisionbox[2] is 0 by default in mtg, btw.)